### PR TITLE
Add apps developed by @TheLastProject

### DIFF
--- a/Plexus.json
+++ b/Plexus.json
@@ -1476,6 +1476,15 @@
     "MG_Notes": "X"
   },
   {
+    "Application": "Catima",
+    "Package": "me.hackerchick.catima",
+    "Version": "2.16.3",
+    "DG_Rating": 4,
+    "MG_Rating": 4,
+    "DG_Notes": "No reported issues",
+    "MG_Notes": "No reported issues"
+  },
+  {
     "Application": "c:geo",
     "Package": "cgeo.geocaching",
     "Version": "0.0.0",
@@ -6633,6 +6642,15 @@
     "MG_Notes": "No reported issues"
   },
   {
+    "Application": "Raise To Answer",
+    "Package": "me.hackerchick.raisetoanswer",
+    "Version": "3.6.5",
+    "DG_Rating": 4,
+    "MG_Rating": 4,
+    "DG_Notes": "No reported issues",
+    "MG_Notes": "No reported issues"
+  },
+  {
     "Application": "Rat On A Scooter XL",
     "Package": "com.donutgames.ratonascooterxl",
     "Version": "0.0.0",
@@ -7090,6 +7108,15 @@
     "MG_Rating": "X",
     "DG_Notes": "Google Play Services Warning, but no effect",
     "MG_Notes": "X"
+  },
+  {
+    "Application": "Share To Inputstick",
+    "Package": "me.hackerchick.sharetoinputstick",
+    "Version": "3.5.2",
+    "DG_Rating": 4,
+    "MG_Rating": 4,
+    "DG_Notes": "No reported issues",
+    "MG_Notes": "No reported issues"
   },
   {
     "Application": "Sharedr",


### PR DESCRIPTION
All these apps are available on both Google Play and F-Droid, with both versions being exactly the same. They are developed to not depend on Google Play Services.

I don't know if it's "okay" for developers to review their own apps (you could argue there would be a conflict of interest), but this project is really cool and I'd like to help this project by making the list longer and reassure my users that my apps won't ever force them to depend on Google Play Services in any way.

For reviews, I run my own apps on my own device (Android 11, LineageOS for microG on a FP3) and develop partially on my device and partially on several Android Studio emulators without Google Play Services.

I also don't know if you care how popular an app is before it is added, so here are some basic Google Play statistics:
Catima: 9,779 active devices
Raise To Answer: 8,535 active devices
Share To InputStick: 51 active devices (yup, this one is very niche)

Do with this PR as you want, if you don't want devs reviewing their own stuff feel free to close, no hard feeling :)