### PR TITLE
Disable `MissingTranslation` lint check

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,10 @@ android {
         viewBinding = true
         buildConfig = true
     }
+
+    lint {
+        disable += "MissingTranslation" // Translations are crowd-sourced.
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This is only useful for commercial apps, Plexus is translated by contributors, it won't be 100% translated always, and neither adding english sources or using machine translations is ideal.